### PR TITLE
Fix getting fuelToken

### DIFF
--- a/src/handlers/newDeviceKey.js
+++ b/src/handlers/newDeviceKey.js
@@ -69,7 +69,7 @@ class NewDeviceKeyHandler {
     console.log(dRequestToken);
 
     const pubKey = dRequestToken.doc.publicKey.find(
-      pub => pub.type === "Secp256k1VerificationKey2018"
+      pub => pub.type === "EcdsaPublicKeySecp256k1"
     );
     const address =
       pubKey.ethereumAddress || toEthereumAddress(pubKey.publicKeyHex);


### PR DESCRIPTION
The 502 error was because no publicKey type was of the `Secp256k1VerificationKey2018` type, therefore there's no `ethereumAddress` of `undefined`.

I changed to an existing type (after observation on the nisaba logs), if this is incorrect (maybe ticket-demo is not updated?, or getting the address should have a fallback option?) feel free to close this PR.
```
const pubKey = dRequestToken.doc.publicKey.find(
      pub => pub.type === "Secp256k1VerificationKey2018"
    );
    const address =
      pubKey.ethereumAddress || toEthereumAddress(pubKey.publicKeyHex);
```